### PR TITLE
minor bugfix

### DIFF
--- a/vdisk/__init__.py
+++ b/vdisk/__init__.py
@@ -78,7 +78,8 @@ def setup_argument_parser():
                         metavar="<level>",
                         help=("Set log level, valid values are: "
                               "DEBUG, INFO, ERROR. Default: INFO"),
-                        type=lambda l: getattr(logging, l, logging.INFO))
+                        type=lambda l: getattr(logging, l.upper(),
+                                               logging.INFO))
     parser.add_argument("-V", "--volume-group",
                         metavar="<name>",
                         help="Name of volume group, default: VolGroup00",


### PR DESCRIPTION
It turns out that the argument to the --log-level is case sensitive and silently fails breaks (or at least behaves in a surprising way) when suppling for example 'debug' (for which getattr returns a reference to the logging.debug function instead of the logging.DEBUG constant).
