### PR TITLE
Remove LICENSE.txt from data_files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,4 @@ setup(
     scripts=[
         "bin/vdisk"
     ],
-    data_files=[
-        ("", ["LICENSE.txt"]),
-    ],
 )


### PR DESCRIPTION
It gets installed directly under /usr for some reason. Shipping it
in the release tarball and on github should be plenty
