### PR TITLE
Fix exception handling for kpartx invocation

### DIFF
--- a/vdisk/helpers.py
+++ b/vdisk/helpers.py
@@ -49,7 +49,7 @@ def mounted_loopback(path, partition_pattern="/dev/mapper/{0}"):
         exitcode, out, err = kpartx("-v", "-a", loop, capture=True,
                                     remove_empty=True)
     except:
-        losetup("-d", path)
+        losetup("-d", loop)
         yield
 
     udevadm("settle")


### PR DESCRIPTION
Provide the loopback device, not the disk image to `losetup` when
cleaning up after `kpartx` failed.
